### PR TITLE
Add per-entry stale-value fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ dispatcher-entries:
           return "#FFC0CB"; // pink
         }
       }
+    fallback:
+      mode: "no-value-read"   # none | no-value-read | no-value-change
+      after: "1h"             # Go duration string, e.g. 30s, 90m, 1h30m
+      value: "? W"            # literal text published when stale
+      color: "#888888"        # hex color of the stale value
 
   - name: "Solar power to topic solar power"
     source:
@@ -404,6 +409,37 @@ dispatcher-entries:
         }
       }
 ```
+
+### Stale-value fallback
+
+Each dispatcher entry may define an optional `fallback`. When a source stops
+delivering fresh data, the dispatcher publishes a configured placeholder value
+and color to the entry's publish topics so the display visibly shows "no data"
+instead of silently keeping a stale reading.
+
+```yaml
+fallback:
+  mode: "no-value-read"   # none | no-value-read | no-value-change
+  after: "1h"             # Go duration: 30s, 90m, 1h30m, ...
+  value: "? °C"           # literal text (published as-is, bypasses outputFormat)
+  color: "#888888"        # 7-character hex color (e.g. #888888)
+```
+
+| Field   | Description |
+| ------- | ----------- |
+| `mode`  | `none` (default, disabled), `no-value-read` (no payload at all arrived within `after`), or `no-value-change` (payloads kept arriving but the resolved value never changed within `after`). |
+| `after` | Stale timeout as a [Go duration](https://pkg.go.dev/time#ParseDuration) string. Note: use `m` for minutes (`90m`, `1h30m`), not `min`. |
+| `value` | Literal text published as the message text. It does **not** pass through `outputFormat` or the `color-script`. |
+| `color` | Literal 7-character hex color for the fallback value. |
+
+Notes:
+
+- The published fallback payload reuses the entry's `icon`: `{"text": <value>, "icon": <icon>, "color": <color>}`.
+- The fallback is published **once** per stale episode and automatically
+  re-armed when fresh data resumes (any payload for `no-value-read`, a changed
+  value for `no-value-change`).
+- `no-value-change` does not fire until at least one value has been seen, and is
+  not applied to tibber-graph outputs (only `no-value-read` applies there).
 
 # MQTT Dispatcher
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -43,6 +44,36 @@ func LoadConfig(path string) (*RootConfig, error) {
 				return nil, fmt.Errorf("ERROR CREATING COLOR CALLBACK FOR CONFIG %d: %v", e_i, err)
 			}
 			cfg.DispatcherEntries[e_i].ColorScriptCallback = colorCallback
+		}
+	}
+
+	for e_i, e := range cfg.DispatcherEntries {
+		if e.Fallback == nil {
+			continue
+		}
+		fb := e.Fallback
+
+		switch fallbackMode(fb.Mode) {
+		case FallbackModeNone, FallbackModeNoValueRead, FallbackModeNoValueChange, "":
+		default:
+			return nil, fmt.Errorf("ERROR: INVALID FALLBACK MODE INDEX %d: '%s'", e_i, fb.Mode)
+		}
+
+		if fb.Mode == "" || fallbackMode(fb.Mode) == FallbackModeNone {
+			continue
+		}
+
+		dur, err := time.ParseDuration(fb.After)
+		if err != nil {
+			return nil, fmt.Errorf("ERROR PARSING FALLBACK DURATION INDEX %d: %v", e_i, err)
+		}
+		if dur <= 0 {
+			return nil, fmt.Errorf("ERROR: FALLBACK DURATION MUST BE POSITIVE INDEX %d: '%s'", e_i, fb.After)
+		}
+		cfg.DispatcherEntries[e_i].FallbackAfter = dur
+
+		if !isValidHexColor(fb.Color) {
+			return nil, fmt.Errorf("ERROR: INVALID FALLBACK COLOR INDEX %d: '%s'", e_i, fb.Color)
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -103,6 +104,60 @@ dispatcher-entries:
 			expectedErrorMessage: "ERROR RUNNING SCRIPT",
 			expectedConfig:       nil,
 		},
+		{
+			name: "InvalidFallbackMode",
+			mockReadFile: func(path string) ([]byte, error) {
+				return []byte(`
+mqtt:
+  broker: "tcp://localhost:1883"
+dispatcher-entries:
+  - fallback:
+      mode: "bogus"
+      after: "1h"
+      value: "? °C"
+      color: "#888888"
+`), nil
+			},
+			expectedError:        true,
+			expectedErrorMessage: "ERROR: INVALID FALLBACK MODE INDEX 0: 'bogus'",
+			expectedConfig:       nil,
+		},
+		{
+			name: "InvalidFallbackDuration",
+			mockReadFile: func(path string) ([]byte, error) {
+				return []byte(`
+mqtt:
+  broker: "tcp://localhost:1883"
+dispatcher-entries:
+  - fallback:
+      mode: "no-value-read"
+      after: "1hour"
+      value: "? °C"
+      color: "#888888"
+`), nil
+			},
+			expectedError:        true,
+			expectedErrorMessage: "ERROR PARSING FALLBACK DURATION INDEX 0",
+			expectedConfig:       nil,
+		},
+		{
+			name: "InvalidFallbackColor",
+			mockReadFile: func(path string) ([]byte, error) {
+				return []byte(`
+mqtt:
+  broker: "tcp://localhost:1883"
+dispatcher-entries:
+  - fallback:
+      mode: "no-value-read"
+      after: "1h"
+      value: "? °C"
+      color: "888888"
+`), nil
+			},
+			expectedError:        true,
+			expectedErrorMessage: "ERROR: INVALID FALLBACK COLOR INDEX 0: '888888'",
+			expectedConfig:       nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -127,4 +182,49 @@ dispatcher-entries:
 			}
 		})
 	}
+}
+
+func TestLoadConfigFallback(t *testing.T) {
+	t.Run("ValidFallback", func(t *testing.T) {
+		osReadFile = func(path string) ([]byte, error) {
+			return []byte(`
+mqtt:
+  broker: "tcp://localhost:1883"
+dispatcher-entries:
+  - fallback:
+      mode: "no-value-read"
+      after: "1h"
+      value: "? °C"
+      color: "#888888"
+`), nil
+		}
+
+		cfg, err := LoadConfig("dummy_path")
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		entry := cfg.DispatcherEntries[0]
+		assert.True(t, entry.HasFallback())
+		assert.Equal(t, time.Hour, entry.FallbackAfter)
+		assert.Equal(t, "? °C", entry.Fallback.Value)
+		assert.Equal(t, "#888888", entry.Fallback.Color)
+	})
+
+	t.Run("FallbackNoneSkipsValidation", func(t *testing.T) {
+		osReadFile = func(path string) ([]byte, error) {
+			return []byte(`
+mqtt:
+  broker: "tcp://localhost:1883"
+dispatcher-entries:
+  - fallback:
+      mode: "none"
+`), nil
+		}
+
+		cfg, err := LoadConfig("dummy_path")
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		entry := cfg.DispatcherEntries[0]
+		assert.False(t, entry.HasFallback())
+		assert.Equal(t, time.Duration(0), entry.FallbackAfter)
+	})
 }

--- a/config/scripts.go
+++ b/config/scripts.go
@@ -15,6 +15,11 @@ const (
 	errorInvalidHex    = "INVALID HEX CODE"
 )
 
+// isValidHexColor reports whether s is a 7-character hex color like "#RRGGBB".
+func isValidHexColor(s string) bool {
+	return len(s) == 7 && s[0] == '#'
+}
+
 func createColorCallback(script string) (func(float64) (string, error), error) {
 	if script == "" {
 		return nil, errors.New(errorEmptyScript)
@@ -36,7 +41,7 @@ func createColorCallback(script string) (func(float64) (string, error), error) {
 	}
 
 	hexcode := res.String()
-	if len(hexcode) != 7 || hexcode[0] != '#' {
+	if !isValidHexColor(hexcode) {
 		return nil, errors.New(errorInvalidHex)
 	}
 

--- a/config/types.go
+++ b/config/types.go
@@ -2,7 +2,10 @@
 // TODO: Update docs for new config!
 package config
 
-import "net/url"
+import (
+	"net/url"
+	"time"
+)
 
 type RootConfig struct {
 	Mqtt              MqttConfig `yaml:"mqtt"`
@@ -26,9 +29,11 @@ type Entry struct {
 	ColorScript     string                `yaml:"color-script,omitempty"`
 	Operation       string                `yaml:"operation,omitempty"`
 	Source          EntrySource           `yaml:"source,omitempty"`
+	Fallback        *FallbackDefinition   `yaml:"fallback,omitempty"`
 
 	// Late binding
 	ColorScriptCallback func(float64) (string, error)
+	FallbackAfter       time.Duration
 }
 
 type MqttTopicDefinition struct {
@@ -46,6 +51,13 @@ type TransformDefinition struct {
 
 type FilterDefinition struct {
 	IgnoreLessThan *float64 `yaml:"ignore-less-than,omitempty"`
+}
+
+type FallbackDefinition struct {
+	Mode  string `yaml:"mode"`
+	After string `yaml:"after"`
+	Value string `yaml:"value"`
+	Color string `yaml:"color"`
 }
 
 type EntrySource struct {
@@ -144,6 +156,29 @@ const (
 	OperatorNone operator = ""
 	OperatorSum  operator = "sum"
 )
+
+type fallbackMode string
+
+const (
+	FallbackModeNone          fallbackMode = "none"
+	FallbackModeNoValueRead   fallbackMode = "no-value-read"
+	FallbackModeNoValueChange fallbackMode = "no-value-change"
+)
+
+// HasFallback reports whether the entry has an enabled stale-value fallback.
+func (e Entry) HasFallback() bool {
+	return e.Fallback != nil &&
+		e.Fallback.Mode != "" &&
+		fallbackMode(e.Fallback.Mode) != FallbackModeNone
+}
+
+// FallbackMode returns the parsed fallback mode (FallbackModeNone if disabled).
+func (e Entry) FallbackMode() fallbackMode {
+	if e.Fallback == nil {
+		return FallbackModeNone
+	}
+	return fallbackMode(e.Fallback.Mode)
+}
 
 func (e Entry) MustAccumulate() (bool, operator) {
 	if e.Source.HttpSource != nil {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -10,18 +10,39 @@ import (
 	"go-mqtt-dispatcher/utils"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/oliveagle/jsonpath"
 )
 
+// now is the clock used by the fallback feature. It is a package var so tests
+// can override it for deterministic time (mirrors getTicker).
+var now = func() time.Time { return time.Now() }
+
 type dispatcherState map[string]map[string]float64
+
+// fallbackTrack records freshness state for one publish topic of an entry with
+// a stale-value fallback configured.
+type fallbackTrack struct {
+	lastActivity time.Time // last time any payload was received (no-value-read)
+	lastValue    float64   // last resolved value (no-value-change)
+	hasValue     bool      // lastValue is valid
+	lastChange   time.Time // last time the resolved value changed (no-value-change)
+	fired        bool      // fallback already published; suppresses re-fire until fresh data
+}
+
 type Dispatcher struct {
 	entries    *[]config.Entry
 	state      dispatcherState
 	mqttClient MqttClient
 	log        func(string)
+
+	// mu protects fallbacks only. The pre-existing `state` map is intentionally
+	// left unsynchronized (unchanged behavior).
+	mu        sync.Mutex
+	fallbacks map[string]*fallbackTrack // key = fallbackKey(entry.Name, pubTopic)
 }
 
 func NewDispatcher(entries *[]config.Entry, mqttClient MqttClient, log func(s string)) (*Dispatcher, error) {
@@ -34,7 +55,12 @@ func NewDispatcher(entries *[]config.Entry, mqttClient MqttClient, log func(s st
 		state:      make(dispatcherState),
 		mqttClient: mqttClient,
 		log:        log,
+		fallbacks:  make(map[string]*fallbackTrack),
 	}, nil
+}
+
+func fallbackKey(entryName, pubTopic string) string {
+	return entryName + "\x00" + pubTopic
 }
 
 // Run starts the dispatcher and creates triggers for the sources and attaches the callbacks
@@ -43,6 +69,10 @@ func (d *Dispatcher) Run() {
 		if entry.Disabled {
 			d.log("Entry disabled: " + entry.Name)
 			continue
+		}
+
+		if entry.HasFallback() {
+			d.startFallbackWatchdog(entry)
 		}
 
 		if entry.Source.MqttSource != nil {
@@ -80,7 +110,7 @@ func (d *Dispatcher) runTibberApi(entry config.TibberApiEntry) {
 				return
 			}
 			for _, topicPub := range entry.GetTopicsToPublish() {
-				c := callbackConfig{Entry: e.GetEntry(), Id: entry.GetID(), TransSource: entry.GetTibberApiSource(), TransTarget: topicPub, Filter: topicPub}
+				c := callbackConfig{Entry: e.GetEntry(), Id: entry.GetID(), PubTopic: topicPub.Topic, TransSource: entry.GetTibberApiSource(), TransTarget: topicPub, Filter: topicPub}
 				d.callback(payload, c, func(msg []byte) {
 					d.mqttClient.Publish(topicPub.Topic, msg)
 				})
@@ -115,7 +145,7 @@ func (d *Dispatcher) runHttp(entry config.HttpEntry) {
 					return
 				}
 				for _, topicPub := range entry.GetTopicsToPublish() {
-					c := callbackConfig{Entry: entry.GetEntry(), Id: url, TransSource: urlDef, TransTarget: topicPub, Filter: topicPub}
+					c := callbackConfig{Entry: entry.GetEntry(), Id: url, PubTopic: topicPub.Topic, TransSource: urlDef, TransTarget: topicPub, Filter: topicPub}
 					d.callback(payload, c, func(msg []byte) {
 						d.mqttClient.Publish(topicPub.Topic, msg)
 					})
@@ -146,7 +176,7 @@ func (d *Dispatcher) runMqtt(entry config.MqttEntry) {
 		err := d.mqttClient.Subscribe(topicSub.Topic, func(payload []byte) {
 			d.log("Received payload for " + topicSub.Topic)
 			for _, topicPub := range entry.GetTopicsToPublish() {
-				c := callbackConfig{Entry: entry.GetEntry(), Id: topicSub.Topic, TransSource: topicSub, TransTarget: topicPub, Filter: topicPub}
+				c := callbackConfig{Entry: entry.GetEntry(), Id: topicSub.Topic, PubTopic: topicPub.Topic, TransSource: topicSub, TransTarget: topicPub, Filter: topicPub}
 				d.callback(payload, c, func(msg []byte) {
 					d.mqttClient.Publish(topicPub.Topic, msg)
 				})
@@ -161,6 +191,7 @@ func (d *Dispatcher) runMqtt(entry config.MqttEntry) {
 type callbackConfig struct {
 	Entry       config.Entry
 	Id          string
+	PubTopic    string
 	TransSource config.TransformSource
 	TransTarget config.TransformTarget
 	Filter      config.Filter
@@ -191,6 +222,12 @@ func (d *Dispatcher) getOutputAsTibberGraph(payload []byte, c config.TransformSo
 
 // callback is called when a new event is received
 func (d *Dispatcher) callback(payload []byte, c callbackConfig, publish func([]byte)) {
+	// Any received payload counts as activity for the no-value-read fallback,
+	// including the tibber-graph, filter, and transform-error paths below.
+	if c.Entry.HasFallback() {
+		d.markActivity(c.Entry.Name, c.PubTopic)
+	}
+
 	if c.TransTarget != nil && c.TransTarget.GetOutputAsTibberGraph() {
 		p, err := d.getOutputAsTibberGraph(payload, c.TransSource)
 		if err != nil {
@@ -225,6 +262,11 @@ func (d *Dispatcher) callback(payload []byte, c callbackConfig, publish func([]b
 		} else {
 			d.log(fmt.Sprintf("Operation '%s' not supported", op))
 		}
+	}
+
+	// Track the resolved (possibly accumulated) value for no-value-change.
+	if c.Entry.HasFallback() {
+		d.markValue(c.Entry.Name, c.PubTopic, val)
 	}
 
 	// Filter
@@ -310,4 +352,140 @@ func (d *Dispatcher) transformPayload(payload []byte, t config.TransformSource) 
 	}
 
 	return result, nil
+}
+
+// markActivity records that a payload was received for a publish topic. Used by
+// the no-value-read fallback. No-op when no track exists (fallback disabled).
+func (d *Dispatcher) markActivity(entryName, pubTopic string) {
+	if entryName == "" || pubTopic == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	t := d.fallbacks[fallbackKey(entryName, pubTopic)]
+	if t == nil {
+		return
+	}
+	t.lastActivity = now()
+	t.fired = false
+}
+
+// markValue records the resolved value for a publish topic. Used by the
+// no-value-change fallback; resets the fallback only when the value changes.
+func (d *Dispatcher) markValue(entryName, pubTopic string, val float64) {
+	if entryName == "" || pubTopic == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	t := d.fallbacks[fallbackKey(entryName, pubTopic)]
+	if t == nil {
+		return
+	}
+	n := now()
+	t.lastActivity = n
+	if !t.hasValue || t.lastValue != val {
+		t.lastValue = val
+		t.hasValue = true
+		t.lastChange = n
+		t.fired = false
+	}
+}
+
+// seedFallback initializes tracking state for each publish topic of an entry so
+// markActivity/markValue have something to update and a never-delivering source
+// can still go stale (relative to startup).
+func (d *Dispatcher) seedFallback(entry config.Entry) {
+	start := now()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, pub := range entry.TopicsToPublish {
+		k := fallbackKey(entry.Name, pub.Topic)
+		if d.fallbacks[k] == nil {
+			d.fallbacks[k] = &fallbackTrack{lastActivity: start, lastChange: start}
+		}
+	}
+}
+
+// fireFallbacksIfStale publishes the fallback payload to any of the entry's
+// publish topics that have gone stale, marking each as fired so it is published
+// at most once per stale episode.
+func (d *Dispatcher) fireFallbacksIfStale(entry config.Entry) {
+	n := now()
+	mode := entry.FallbackMode()
+	after := entry.FallbackAfter
+
+	var due []string
+	d.mu.Lock()
+	for _, pub := range entry.TopicsToPublish {
+		t := d.fallbacks[fallbackKey(entry.Name, pub.Topic)]
+		if t == nil || t.fired {
+			continue
+		}
+		var stale bool
+		switch mode {
+		case config.FallbackModeNoValueRead:
+			stale = n.Sub(t.lastActivity) >= after
+		case config.FallbackModeNoValueChange:
+			stale = t.hasValue && n.Sub(t.lastChange) >= after
+		}
+		if stale {
+			t.fired = true
+			due = append(due, pub.Topic)
+		}
+	}
+	d.mu.Unlock()
+
+	// Publish outside the lock.
+	if len(due) == 0 {
+		return
+	}
+	payload := d.fallbackPayload(entry)
+	for _, topic := range due {
+		d.log("Fallback firing for " + entry.Name + " -> " + topic)
+		d.mqttClient.Publish(topic, payload)
+	}
+}
+
+// startFallbackWatchdog seeds tracking state and starts a goroutine that
+// periodically publishes the configured fallback once a topic goes stale.
+func (d *Dispatcher) startFallbackWatchdog(entry config.Entry) {
+	d.seedFallback(entry)
+
+	interval := entry.FallbackAfter / 4
+	if interval < time.Second {
+		interval = time.Second
+	}
+
+	d.log(fmt.Sprintf("- Fallback watchdog for %s: mode=%s after=%s", entry.Name, entry.FallbackMode(), entry.FallbackAfter))
+
+	go func(entry config.Entry) {
+		ticker := getTicker(interval)
+		defer ticker.Stop()
+
+		d.fireFallbacksIfStale(entry)
+		for range ticker.C {
+			d.fireFallbacksIfStale(entry)
+			if interruptRunHttpTickerAfterTick {
+				return
+			}
+		}
+	}(entry)
+}
+
+// fallbackPayload builds the literal fallback message for an entry. The value
+// and color are literal (they bypass outputFormat and the color-script); the
+// entry's icon is reused.
+func (d *Dispatcher) fallbackPayload(entry config.Entry) []byte {
+	msg := publishMessage{
+		Text:  entry.Fallback.Value,
+		Color: entry.Fallback.Color,
+		Icon:  entry.Icon,
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		d.log(fmt.Sprintf("Error marshaling fallback json: %v", err))
+		return errorPayload
+	}
+	return b
 }

--- a/dispatcher/fallback_test.go
+++ b/dispatcher/fallback_test.go
@@ -1,0 +1,198 @@
+package dispatcher
+
+import (
+	"go-mqtt-dispatcher/config"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fbClock backs an injectable, race-free test clock for the fallback feature.
+var fbClock atomic.Int64
+
+func useTestClock(base time.Time) {
+	fbClock.Store(base.UnixNano())
+	now = func() time.Time { return time.Unix(0, fbClock.Load()) }
+}
+
+func setClock(t time.Time) { fbClock.Store(t.UnixNano()) }
+
+// fallbackPayloadJSON is the expected payload for the test entries below.
+const fallbackPayloadJSON = `{"text":"? °C","icon":"pool","color":"#888888"}`
+
+func newFallbackEntry(mode string, pubTopics ...string) config.Entry {
+	pubs := make([]config.MqttTopicDefinition, 0, len(pubTopics))
+	for _, p := range pubTopics {
+		pubs = append(pubs, config.MqttTopicDefinition{Topic: p, Transform: config.TransformDefinition{OutputFormat: "%.1f C"}})
+	}
+	return config.Entry{
+		Name: "tempEntry",
+		Icon: "pool",
+		Source: config.EntrySource{
+			MqttSource: &config.MqttSource{
+				TopicsToSubscribe: []config.MqttTopicDefinition{
+					{Topic: "sensor/temp", Transform: config.TransformDefinition{JsonPath: "$.t"}},
+				},
+			},
+		},
+		TopicsToPublish: pubs,
+		Fallback:        &config.FallbackDefinition{Mode: mode, After: "1h", Value: "? °C", Color: "#888888"},
+		FallbackAfter:   time.Hour,
+	}
+}
+
+// setup builds a dispatcher, seeds fallback tracking, and wires the mqtt
+// subscription so SimulateMessage drives the real callback path.
+func setup(t *testing.T, entry config.Entry) (*Dispatcher, *MockMqttClient) {
+	t.Helper()
+	log := func(s string) { t.Log(s) }
+	mc := NewMockMqttClient(log)
+	d, err := NewDispatcher(&[]config.Entry{entry}, mc, log)
+	require.NoError(t, err)
+	if entry.HasFallback() {
+		d.seedFallback(entry)
+	}
+	d.runMqtt(config.MqttEntryImpl{Entry: entry})
+	return d, mc
+}
+
+func TestFallbackNoValueReadFires(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := newFallbackEntry("no-value-read", "display/temp")
+	d, mc := setup(t, entry)
+
+	// Not yet stale.
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, 0, mc.PublishCount["display/temp"])
+
+	// Past the timeout with no data -> fires once.
+	setClock(base.Add(2 * time.Hour))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, 1, mc.PublishCount["display/temp"])
+	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+
+	// Fire-once: subsequent checks do not republish.
+	d.fireFallbacksIfStale(entry)
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, 1, mc.PublishCount["display/temp"])
+}
+
+func TestFallbackNoValueReadResetByMessage(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := newFallbackEntry("no-value-read", "display/temp")
+	d, mc := setup(t, entry)
+
+	// A message arrives before the timeout, resetting the activity clock.
+	setClock(base.Add(30 * time.Minute))
+	mc.SimulateMessage("sensor/temp", []byte(`{"t":42}`))
+
+	// 1h after startup but only 31m after the message -> not stale.
+	setClock(base.Add(1*time.Hour + 1*time.Minute))
+	before := mc.PublishCount["display/temp"]
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, before, mc.PublishCount["display/temp"])
+
+	// Past 1h after the message -> fires.
+	setClock(base.Add(1*time.Hour + 31*time.Minute))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
+	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+}
+
+func TestFallbackNoValueChangeFires(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := newFallbackEntry("no-value-change", "display/temp")
+	d, mc := setup(t, entry)
+
+	// Before any value, change-mode must not fire even past the timeout.
+	setClock(base.Add(2 * time.Hour))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, 0, mc.PublishCount["display/temp"])
+
+	// First value seen.
+	mc.SimulateMessage("sensor/temp", []byte(`{"t":42}`))
+	before := mc.PublishCount["display/temp"]
+
+	// Same value, well past the timeout -> fires.
+	setClock(base.Add(4 * time.Hour))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
+	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+}
+
+func TestFallbackNoValueChangeResetByChange(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := newFallbackEntry("no-value-change", "display/temp")
+	d, mc := setup(t, entry)
+
+	mc.SimulateMessage("sensor/temp", []byte(`{"t":42}`))
+
+	// A changed value before the timeout resets the change clock.
+	setClock(base.Add(50 * time.Minute))
+	mc.SimulateMessage("sensor/temp", []byte(`{"t":43}`))
+	before := mc.PublishCount["display/temp"]
+
+	// Only 30m since the change -> not stale.
+	setClock(base.Add(1*time.Hour + 20*time.Minute))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, before, mc.PublishCount["display/temp"])
+
+	// Past 1h since the change -> fires.
+	setClock(base.Add(1*time.Hour + 51*time.Minute))
+	d.fireFallbacksIfStale(entry)
+	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
+}
+
+func TestFallbackDisabled(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := config.Entry{
+		Name: "noFallback",
+		Source: config.EntrySource{
+			MqttSource: &config.MqttSource{
+				TopicsToSubscribe: []config.MqttTopicDefinition{
+					{Topic: "sensor/temp", Transform: config.TransformDefinition{JsonPath: "$.t"}},
+				},
+			},
+		},
+		TopicsToPublish: []config.MqttTopicDefinition{{Topic: "display/temp"}},
+	}
+	require.False(t, entry.HasFallback())
+
+	d, mc := setup(t, entry)
+
+	// No tracking was seeded; a stale check never publishes a fallback.
+	setClock(base.Add(100 * time.Hour))
+	d.fireFallbacksIfStale(entry)
+	_, ok := mc.PublishedMessages["display/temp"]
+	assert.False(t, ok)
+	assert.Empty(t, d.fallbacks)
+}
+
+func TestFallbackMultipleTopics(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	useTestClock(base)
+
+	entry := newFallbackEntry("no-value-read", "display/a", "display/b")
+	d, mc := setup(t, entry)
+
+	setClock(base.Add(2 * time.Hour))
+	d.fireFallbacksIfStale(entry)
+
+	assert.Equal(t, 1, mc.PublishCount["display/a"])
+	assert.Equal(t, 1, mc.PublishCount["display/b"])
+	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/a"]))
+	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/b"]))
+}

--- a/dispatcher/mqttclientmock_test.go
+++ b/dispatcher/mqttclientmock_test.go
@@ -2,6 +2,7 @@ package dispatcher
 
 type MockMqttClient struct {
 	PublishedMessages map[string][]byte
+	PublishCount      map[string]int
 	Subscriptions     map[string]func([]byte)
 	Log               func(s string)
 }
@@ -15,6 +16,7 @@ func NewMockMqttClient(logger ...func(s string)) *MockMqttClient {
 
 	return &MockMqttClient{
 		PublishedMessages: make(map[string][]byte),
+		PublishCount:      make(map[string]int),
 		Subscriptions:     make(map[string]func([]byte)),
 		Log:               logger[0],
 	}
@@ -23,6 +25,7 @@ func NewMockMqttClient(logger ...func(s string)) *MockMqttClient {
 func (m *MockMqttClient) Publish(topic string, payload []byte) error {
 	m.Log("Publishing to '" + topic + "': '" + string(payload) + "'")
 	m.PublishedMessages[topic] = payload
+	m.PublishCount[topic]++
 	return nil
 }
 


### PR DESCRIPTION
## Context

When a source goes silent (sensor offline, broker hiccup, API down), the last value just sticks on the display forever — there is no way to tell a stale reading from a live one. This adds a per-entry **fallback**: after a configurable time with no fresh data, publish a configured placeholder value and color so the display visibly shows "no data", auto-restoring when fresh data resumes.

## Modes

- **`no-value-read`** — the source delivered *no payload at all* within the window.
- **`no-value-change`** — payloads kept arriving but the resolved value *never changed* within the window.
- **`none`** (default) — disabled.

## Config

```yaml
fallback:
  mode: "no-value-read"   # none | no-value-read | no-value-change
  after: "1h"             # Go duration: 30s, 90m, 1h30m, ...
  value: "? °C"           # literal text (bypasses outputFormat / color-script)
  color: "#888888"        # 7-char hex
```

The fallback payload reuses the entry's `icon`, fires **once** per stale episode, and re-arms on fresh data (any payload for read-mode, a changed value for change-mode).

## Changes

- **config**: `FallbackDefinition` + `Entry.Fallback`/`FallbackAfter`, mode constants, `HasFallback()`. Validation in `LoadConfig` (mode enum, `time.ParseDuration`, hex color). Extracted/reused `isValidHexColor`.
- **dispatcher**: injectable `now` clock; mutex-guarded per-(entry,topic) `fallbacks` tracking updated in `callback()`; `seedFallback`/`fireFallbacksIfStale` + per-entry watchdog launched from `Run()`.
- **tests**: config validation cases; `dispatcher/fallback_test.go` covering both modes, reset, fire-once, disabled, multi-topic (atomic test clock, no goroutine timing); `PublishCount` added to the mock.
- **docs**: README example + "Stale-value fallback" subsection.

## Verification

`go build ./...`, `go vet ./...`, `gofmt` clean, `go test ./...` passes. New tests verified race-clean under `-race`.

> Note: `go test -race` surfaces a **pre-existing** data race in `TestRunHttp` (existing `getTicker`/`interruptRunHttpTickerAfterTick` globals) that also fails on `main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)