### PR TITLE
Fix data races surfaced by go test -race

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -39,8 +40,8 @@ type Dispatcher struct {
 	mqttClient MqttClient
 	log        func(string)
 
-	// mu protects fallbacks only. The pre-existing `state` map is intentionally
-	// left unsynchronized (unchanged behavior).
+	// mu guards the shared maps below (state and fallbacks), which are accessed
+	// concurrently by the per-source goroutines and the fallback watchdog.
 	mu        sync.Mutex
 	fallbacks map[string]*fallbackTrack // key = fallbackKey(entry.Name, pubTopic)
 }
@@ -120,7 +121,7 @@ func (d *Dispatcher) runTibberApi(entry config.TibberApiEntry) {
 		tickFunc(entry) // First tick
 		for range ticker.C {
 			tickFunc(entry)
-			if interruptRunHttpTickerAfterTick {
+			if interruptRunHttpTickerAfterTick.Load() {
 				return
 			}
 		}
@@ -155,7 +156,7 @@ func (d *Dispatcher) runHttp(entry config.HttpEntry) {
 			tickFunc(u, e) // First tick
 			for range ticker.C {
 				tickFunc(u, e)
-				if interruptRunHttpTickerAfterTick {
+				if interruptRunHttpTickerAfterTick.Load() {
 					return
 				}
 			}
@@ -164,9 +165,10 @@ func (d *Dispatcher) runHttp(entry config.HttpEntry) {
 	}
 }
 
-var (
-	interruptRunHttpTickerAfterTick = false
-)
+// interruptRunHttpTickerAfterTick lets tests stop the ticker loops after one
+// tick. It is atomic because background goroutines may still read it while a
+// subsequent test writes it (e.g. under `go test -count`).
+var interruptRunHttpTickerAfterTick atomic.Bool
 
 // runMqtt creates a trigger for the mqtt source and attaches the callback
 func (d *Dispatcher) runMqtt(entry config.MqttEntry) {
@@ -245,8 +247,10 @@ func (d *Dispatcher) callback(payload []byte, c callbackConfig, publish func([]b
 		return
 	}
 
-	// Accumulate
+	// Accumulate. d.state is shared across the per-source goroutines (HTTP
+	// pollers, tibber poller, MQTT callbacks), so guard it with d.mu.
 	if must, op := c.Entry.MustAccumulate(); must {
+		d.mu.Lock()
 		if _, ok := d.state[c.Entry.Name]; !ok {
 			d.state[c.Entry.Name] = make(map[string]float64)
 		}
@@ -258,8 +262,11 @@ func (d *Dispatcher) callback(payload []byte, c callbackConfig, publish func([]b
 				sum += v
 			}
 			val = sum
-			d.log(fmt.Sprintf("Accumulated value for %s: %f, from %v values ", c.Entry.Name, val, len(d.state[c.Entry.Name])))
+			count := len(d.state[c.Entry.Name])
+			d.mu.Unlock()
+			d.log(fmt.Sprintf("Accumulated value for %s: %f, from %v values ", c.Entry.Name, val, count))
 		} else {
+			d.mu.Unlock()
 			d.log(fmt.Sprintf("Operation '%s' not supported", op))
 		}
 	}
@@ -466,7 +473,7 @@ func (d *Dispatcher) startFallbackWatchdog(entry config.Entry) {
 		d.fireFallbacksIfStale(entry)
 		for range ticker.C {
 			d.fireFallbacksIfStale(entry)
-			if interruptRunHttpTickerAfterTick {
+			if interruptRunHttpTickerAfterTick.Load() {
 				return
 			}
 		}

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -50,7 +50,7 @@ func TestRunHttp(t *testing.T) {
 	}
 
 	// Run the dispatcher
-	interruptRunHttpTickerAfterTick = true
+	interruptRunHttpTickerAfterTick.Store(true)
 	getTicker = func(_ time.Duration) *time.Ticker {
 		return time.NewTicker(1 * time.Millisecond)
 	}
@@ -61,7 +61,7 @@ func TestRunHttp(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Check if the message was published
-	if msg, ok := mqttClient.PublishedMessages["test/topic"]; !ok {
+	if msg, ok := mqttClient.GetPublishedMessage("test/topic"); !ok {
 		t.Errorf("Expected message to be published to test/topic")
 	} else {
 		expectedMsg := `{"text":"42"}`
@@ -112,7 +112,7 @@ func TestRunMqtt(t *testing.T) {
 	mqttClient.SimulateMessage("test/subscribe", payload)
 
 	// Check if the message was published
-	if msg, ok := mqttClient.PublishedMessages["test/publish"]; !ok {
+	if msg, ok := mqttClient.GetPublishedMessage("test/publish"); !ok {
 		t.Errorf("Expected message to be published to test/publish")
 	} else {
 		if string(msg) != `{"text":"42"}` {
@@ -237,7 +237,7 @@ func TestCallback(t *testing.T) {
 			})
 
 			// Check if the message was published
-			if msg, ok := mqttClient.PublishedMessages["test/publish"]; !ok {
+			if msg, ok := mqttClient.GetPublishedMessage("test/publish"); !ok {
 				t.Errorf("Expected message to be published to test/publish")
 			} else {
 				if string(msg) != tt.expected {

--- a/dispatcher/fallback_test.go
+++ b/dispatcher/fallback_test.go
@@ -20,6 +20,12 @@ func useTestClock(base time.Time) {
 
 func setClock(t time.Time) { fbClock.Store(t.UnixNano()) }
 
+// lastMessage returns the last payload published to a topic as a string.
+func lastMessage(mc *MockMqttClient, topic string) string {
+	msg, _ := mc.GetPublishedMessage(topic)
+	return string(msg)
+}
+
 // fallbackPayloadJSON is the expected payload for the test entries below.
 const fallbackPayloadJSON = `{"text":"? °C","icon":"pool","color":"#888888"}`
 
@@ -68,18 +74,18 @@ func TestFallbackNoValueReadFires(t *testing.T) {
 
 	// Not yet stale.
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, 0, mc.PublishCount["display/temp"])
+	assert.Equal(t, 0, mc.GetPublishCount("display/temp"))
 
 	// Past the timeout with no data -> fires once.
 	setClock(base.Add(2 * time.Hour))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, 1, mc.PublishCount["display/temp"])
-	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+	assert.Equal(t, 1, mc.GetPublishCount("display/temp"))
+	assert.Equal(t, fallbackPayloadJSON, lastMessage(mc, "display/temp"))
 
 	// Fire-once: subsequent checks do not republish.
 	d.fireFallbacksIfStale(entry)
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, 1, mc.PublishCount["display/temp"])
+	assert.Equal(t, 1, mc.GetPublishCount("display/temp"))
 }
 
 func TestFallbackNoValueReadResetByMessage(t *testing.T) {
@@ -95,15 +101,15 @@ func TestFallbackNoValueReadResetByMessage(t *testing.T) {
 
 	// 1h after startup but only 31m after the message -> not stale.
 	setClock(base.Add(1*time.Hour + 1*time.Minute))
-	before := mc.PublishCount["display/temp"]
+	before := mc.GetPublishCount("display/temp")
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, before, mc.PublishCount["display/temp"])
+	assert.Equal(t, before, mc.GetPublishCount("display/temp"))
 
 	// Past 1h after the message -> fires.
 	setClock(base.Add(1*time.Hour + 31*time.Minute))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
-	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+	assert.Equal(t, before+1, mc.GetPublishCount("display/temp"))
+	assert.Equal(t, fallbackPayloadJSON, lastMessage(mc, "display/temp"))
 }
 
 func TestFallbackNoValueChangeFires(t *testing.T) {
@@ -116,17 +122,17 @@ func TestFallbackNoValueChangeFires(t *testing.T) {
 	// Before any value, change-mode must not fire even past the timeout.
 	setClock(base.Add(2 * time.Hour))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, 0, mc.PublishCount["display/temp"])
+	assert.Equal(t, 0, mc.GetPublishCount("display/temp"))
 
 	// First value seen.
 	mc.SimulateMessage("sensor/temp", []byte(`{"t":42}`))
-	before := mc.PublishCount["display/temp"]
+	before := mc.GetPublishCount("display/temp")
 
 	// Same value, well past the timeout -> fires.
 	setClock(base.Add(4 * time.Hour))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
-	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/temp"]))
+	assert.Equal(t, before+1, mc.GetPublishCount("display/temp"))
+	assert.Equal(t, fallbackPayloadJSON, lastMessage(mc, "display/temp"))
 }
 
 func TestFallbackNoValueChangeResetByChange(t *testing.T) {
@@ -141,17 +147,17 @@ func TestFallbackNoValueChangeResetByChange(t *testing.T) {
 	// A changed value before the timeout resets the change clock.
 	setClock(base.Add(50 * time.Minute))
 	mc.SimulateMessage("sensor/temp", []byte(`{"t":43}`))
-	before := mc.PublishCount["display/temp"]
+	before := mc.GetPublishCount("display/temp")
 
 	// Only 30m since the change -> not stale.
 	setClock(base.Add(1*time.Hour + 20*time.Minute))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, before, mc.PublishCount["display/temp"])
+	assert.Equal(t, before, mc.GetPublishCount("display/temp"))
 
 	// Past 1h since the change -> fires.
 	setClock(base.Add(1*time.Hour + 51*time.Minute))
 	d.fireFallbacksIfStale(entry)
-	assert.Equal(t, before+1, mc.PublishCount["display/temp"])
+	assert.Equal(t, before+1, mc.GetPublishCount("display/temp"))
 }
 
 func TestFallbackDisabled(t *testing.T) {
@@ -176,7 +182,7 @@ func TestFallbackDisabled(t *testing.T) {
 	// No tracking was seeded; a stale check never publishes a fallback.
 	setClock(base.Add(100 * time.Hour))
 	d.fireFallbacksIfStale(entry)
-	_, ok := mc.PublishedMessages["display/temp"]
+	_, ok := mc.GetPublishedMessage("display/temp")
 	assert.False(t, ok)
 	assert.Empty(t, d.fallbacks)
 }
@@ -191,8 +197,8 @@ func TestFallbackMultipleTopics(t *testing.T) {
 	setClock(base.Add(2 * time.Hour))
 	d.fireFallbacksIfStale(entry)
 
-	assert.Equal(t, 1, mc.PublishCount["display/a"])
-	assert.Equal(t, 1, mc.PublishCount["display/b"])
-	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/a"]))
-	assert.Equal(t, fallbackPayloadJSON, string(mc.PublishedMessages["display/b"]))
+	assert.Equal(t, 1, mc.GetPublishCount("display/a"))
+	assert.Equal(t, 1, mc.GetPublishCount("display/b"))
+	assert.Equal(t, fallbackPayloadJSON, lastMessage(mc, "display/a"))
+	assert.Equal(t, fallbackPayloadJSON, lastMessage(mc, "display/b"))
 }

--- a/dispatcher/mqttclientmock_test.go
+++ b/dispatcher/mqttclientmock_test.go
@@ -1,6 +1,11 @@
 package dispatcher
 
+import "sync"
+
 type MockMqttClient struct {
+	// mu guards all maps below; Publish/Subscribe are invoked from background
+	// goroutines (HTTP/tibber pollers, fallback watchdog) while tests read state.
+	mu                sync.Mutex
 	PublishedMessages map[string][]byte
 	PublishCount      map[string]int
 	Subscriptions     map[string]func([]byte)
@@ -24,6 +29,8 @@ func NewMockMqttClient(logger ...func(s string)) *MockMqttClient {
 
 func (m *MockMqttClient) Publish(topic string, payload []byte) error {
 	m.Log("Publishing to '" + topic + "': '" + string(payload) + "'")
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.PublishedMessages[topic] = payload
 	m.PublishCount[topic]++
 	return nil
@@ -31,6 +38,8 @@ func (m *MockMqttClient) Publish(topic string, payload []byte) error {
 
 func (m *MockMqttClient) Subscribe(topic string, callback func([]byte)) error {
 	m.Log("Subscribing to '" + topic + "'")
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Subscriptions[topic] = callback
 	return nil
 }
@@ -38,13 +47,35 @@ func (m *MockMqttClient) Subscribe(topic string, callback func([]byte)) error {
 // Helper method for testing
 func (m *MockMqttClient) SimulateMessage(topic string, payload []byte) {
 	m.Log("Simulating message for '" + topic + "'")
-	if callback, ok := m.Subscriptions[topic]; ok {
+	// Resolve the callback under the lock, but invoke it outside to avoid
+	// deadlocking with Publish (which the callback calls).
+	m.mu.Lock()
+	callback, ok := m.Subscriptions[topic]
+	m.mu.Unlock()
+	if ok {
 		callback(payload)
 	}
 }
 
 // IsSubscribed checks if a topic has an active subscription
 func (m *MockMqttClient) IsSubscribed(topic string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	_, exists := m.Subscriptions[topic]
 	return exists
+}
+
+// GetPublishedMessage returns the last payload published to a topic.
+func (m *MockMqttClient) GetPublishedMessage(topic string) ([]byte, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msg, ok := m.PublishedMessages[topic]
+	return msg, ok
+}
+
+// GetPublishCount returns the number of times a topic was published to.
+func (m *MockMqttClient) GetPublishCount(topic string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.PublishCount[topic]
 }


### PR DESCRIPTION
## Context

`go test -race` failed on `TestRunHttp`. Investigating the report turned up **two distinct races** — one in the tests and, more importantly, one real one in production code.

## 1. Production race (the important one)

The accumulation map `d.state` is read and written from multiple goroutines with no synchronization:
- one HTTP poller goroutine **per URL** (`runHttp`),
- the tibber poller goroutine (`runTibberApi`),
- MQTT subscription callbacks.

For an accumulating entry (`operation: "sum"` with several sources — e.g. the "Solar power" entry with two sources), these goroutines concurrently touch `d.state[entryName]`, which is a genuine data race that could corrupt the map or produce wrong sums.

**Fix:** guard `d.state` with the existing `d.mu` mutex; the log call is kept outside the lock.

## 2. Test races (what `-race` actually flagged)

- `MockMqttClient`'s maps were written by background poller goroutines (`Publish`) while the test goroutine read them directly.
- `interruptRunHttpTickerAfterTick` (a plain `bool`) was written by one test while a leftover goroutine from a previous iteration still read it in its loop — reproducible under `go test -count`.

**Fix:**
- Make `MockMqttClient` thread-safe: a mutex plus `GetPublishedMessage` / `GetPublishCount` accessors; tests read through them.
- Convert `interruptRunHttpTickerAfterTick` to `atomic.Bool`.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test -race ./...` clean.
- `go test -race -count=20 ./dispatcher/` clean (previously failed intermittently from `-count=2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)